### PR TITLE
Fixed compilation errors

### DIFF
--- a/extendr-polars/Cargo.toml
+++ b/extendr-polars/Cargo.toml
@@ -10,13 +10,14 @@ description = "extendr bindings to polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polars = { version = "*", default_features = false, features = ["dtype-struct"]}
+polars = { version = "*", features = ["dtype-struct"]}
 polars-core = { version = "*", default_features = false }
 polars-plan = { version = "*", default_features = false, optional = true }
 polars-lazy = { version = "*", default_features = false, optional = true }
 thiserror = "1"
 ciborium = { version = "0.2.0", optional = true }
 extendr-api = "*"
+arrow = "51.0.0"
 
 
 

--- a/extendr-polars/Cargo.toml
+++ b/extendr-polars/Cargo.toml
@@ -11,13 +11,12 @@ description = "extendr bindings to polars"
 
 [dependencies]
 polars = { version = "*", features = ["dtype-struct"]}
-polars-core = { version = "*", default_features = false }
+polars-core = { version = "*" }
 polars-plan = { version = "*", default_features = false, optional = true }
 polars-lazy = { version = "*", default_features = false, optional = true }
 thiserror = "1"
 ciborium = { version = "0.2.0", optional = true }
 extendr-api = "*"
-arrow = "51.0.0"
 
 
 

--- a/extendr-polars/src/export_dataframe.rs
+++ b/extendr-polars/src/export_dataframe.rs
@@ -25,7 +25,7 @@ pub fn to_rpolars_dataframe(df: pl::DataFrame) -> EResult<Robj> {
 // safety: requires a valid array stream pointer, robj_str_ref
 unsafe fn export_df_as_stream(df: pl::DataFrame, robj_str_ref: &Robj) -> EResult<()> {
     let stream_ptr = rptr::robj_str_ptr_to_usize(robj_str_ref)? as *mut ffi::ArrowArrayStream;
-    let schema = df.schema().to_arrow();
+    let schema = df.schema().to_arrow(true);
     let data_type = pl::ArrowDataType::Struct(schema.fields);
     let field = pl::ArrowField::new("", data_type, false);
     let iter_boxed = Box::new(odi::OwnedDataFrameIterator::new(df));


### PR DESCRIPTION
Fixed some compilation error. Build works, but `polars:::export_df_to_arrow_stream` has been removed, thus still unusable. Unable to find equivalent for quick fix. 